### PR TITLE
Fix metrics bug showing results from all actions

### DIFF
--- a/assessmentHurdleExamples/dockerDSCWrittenDemo.sh
+++ b/assessmentHurdleExamples/dockerDSCWrittenDemo.sh
@@ -4,14 +4,20 @@ export TOKEN=admin
 
 export AGENCY_DIR="./written_test"
 /bin/bash ./util/hiringAction.sh
+/bin/bash ./util/hiringActionDocker.sh
+
 
 # export AGENCY_DIR="./prod/DSC_written/design"
-# /bin/bash ./util/hiringAction.sh
+# /bin/bash ./util/hiringActionDocker.sh
+
 # export AGENCY_DIR="./prod/DSC_written/data"
-# /bin/bash ./util/hiringAction.sh
+# /bin/bash ./util/hiringActionDocker.sh
+
 # export AGENCY_DIR="./prod/DSC_written/swe"
-# /bin/bash ./util/hiringAction.sh
+# /bin/bash ./util/hiringActionDocker.sh
+
 # export AGENCY_DIR="./prod/DSC_written/product"
-# /bin/bash ./util/hiringAction.sh
+# /bin/bash ./util/hiringActionDocker.sh
+
 # export AGENCY_DIR="./prod/DSC_written/cyber"
-# /bin/bash ./util/hiringAction.sh
+# /bin/bash ./util/hiringActionDocker.sh

--- a/assessmentHurdleExamples/util/addDockerUsers.sh
+++ b/assessmentHurdleExamples/util/addDockerUsers.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+: "${HOST?Need to set HOST}";
+: "${TOKEN?Need to set TOKEN}";
+: "${HA_ID?Need to set HA_ID}";
+export USERS_FILE="./util/users.json";
+# update all SME/HR
+printf "\nAdding users for the hiring action\n";
+
+HTTP_CODE=$(curl --write-out '%{http_code}' --silent --output /dev/null -X PUT -H "Authorization: token ${TOKEN}" -H "Content-Type: application/json" -d @${USERS_FILE} ${HOST}/api/assessment-hurdle/${HA_ID}/users);
+
+if [ $HTTP_CODE \> 299 ]; then exit 1; fi;

--- a/assessmentHurdleExamples/util/hiringActionDocker.sh
+++ b/assessmentHurdleExamples/util/hiringActionDocker.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Called from parent of `util`
+# expects the following env vars to be set:
+
+: "${HOST?Need to set HOST}";
+: "${TOKEN?Need to set TOKEN}";
+: "${AGENCY_DIR?Need to set AGENCY_DIR}";
+
+printf "HOST: $HOST\nTOKEN: $TOKEN\nAGENCY_DIR: $AGENCY_DIR\n";
+
+# This creates the actual hiring action
+HA_ID=`curl --silent -X PUT -H "Authorization: token ${TOKEN}" -H "Content-Type: application/json" -d @${AGENCY_DIR}/assessmentHurdle.json ${HOST}/api/assessment-hurdle/ | jq '.data.id'`;
+
+if [[ $HA_ID == null ]]; 
+
+then 
+    printf "\nNo hiring action ID";
+    exit 1; 
+fi;
+# Remove leading `"` 
+HA_ID="${HA_ID%\"}" 
+# Remove trailing `"``
+export HA_ID="${HA_ID#\"}"
+
+: "${HA_ID?Need to set HA_ID}"
+printf "\nHA ID: ${HA_ID}\n";
+
+printf "$AGENCY_DIR : $HA_ID\n" >> last_run_ha_id.txt
+
+export APPLICANTS_FILE=${AGENCY_DIR}/applicants.csv
+export USERS_FILE=${AGENCY_DIR}/users.json
+
+# Assumes being called from the parent directory.
+# These can all be called independently
+# with the correct env vars.
+/bin/bash ./util/addUsers.sh && \
+/bin/bash ./util/addSpecialties.sh && \
+/bin/bash ./util/addApplicants.sh && 
+/bin/bash ./util/addDockerUsers.sh && \
+printf "\n\nHiring action successfully created!" && exit;
+printf "\n\nHiring action creation failed";

--- a/assessmentHurdleExamples/util/users.json
+++ b/assessmentHurdleExamples/util/users.json
@@ -1,0 +1,35 @@
+{
+  "userSetup": [
+    {
+      "role": 1,
+      "users": [
+        {
+          "email": "smeqa_reviewer@usds.gov",
+          "name": "Hr 1 Tester"
+        }
+      ]
+    },
+
+    {
+      "role": 2,
+      "users": [
+        {
+          "email": "smeqa_evaluator_one@usds.gov",
+          "name": "SME 1 Tester"
+        },
+        {
+          "email": "smeqa_evaluator_two@usds.gov",
+          "name": "SME 2 Tester"
+        },
+        {
+          "email": "smeqa_evaluator_three@usds.gov",
+          "name": "SME 3 Tester"
+        },
+        {
+          "email": "smeqa_evaluator_four@usds.gov",
+          "name": "SME 4 Tester"
+        }
+      ]
+    }
+  ]
+}

--- a/db/migrations/35_fix_multiple_action_metrics.sql
+++ b/db/migrations/35_fix_multiple_action_metrics.sql
@@ -1,0 +1,25 @@
+-- There was an issue with the view joining too many recused applicants
+CREATE OR REPLACE VIEW evaluator_recusals AS
+SELECT 
+    recused_evaluator_id recuser
+    ,COUNT(DISTINCT(applicant_id)) recused
+	,assessment_hurdle_id
+    FROM applicant_recusals
+	LEFT JOIN applicant a ON a.id = applicant_id
+    GROUP BY recused_evaluator_id, assessment_hurdle_id;
+
+CREATE OR REPLACE VIEW evaluator_metrics AS
+SELECT
+	evaluator
+	, aa.assessment_hurdle_id
+	, au.name
+	, COUNT(*) FILTER (WHERE approved IS null) pending_review
+	, COUNT(*) FILTER (WHERE approved IS false) pending_amendment
+	, COUNT(*) FILTER (WHERE approved IS true) completed
+	, COALESCE(MAX(recused), 0) recusals
+FROM app_user au
+LEFT JOIN application_evaluation ae ON ae.evaluator = au.id
+LEFT JOIN application a on a.id = ae.application_id
+LEFT JOIN applicant aa ON aa.id = a.applicant_id
+LEFT JOIN evaluator_recusals er ON er.recuser = au.id
+GROUP BY evaluator, au.name,aa.assessment_hurdle_id;

--- a/db/runs/smeqa-rr/run_prod_35.sh
+++ b/db/runs/smeqa-rr/run_prod_35.sh
@@ -1,0 +1,5 @@
+#/bin/bash
+# Run Dec/16/2021
+. ./prod_env.sh
+
+# psql ${POSTGRES} -a -f ../../migrations/35_fix_multiple_action_metrics.sql

--- a/frontend/src/App/Metrics/index.jsx
+++ b/frontend/src/App/Metrics/index.jsx
@@ -5,6 +5,7 @@ import {
   fetchMetrics,
   selectMetrics,
   selectMetricsStatus,
+  selectCurrentHiringActionId,
 } from "./metricsSlice";
 import Loading from "../commonComponents/Loading";
 import Metrics from "./Metrics";
@@ -13,6 +14,7 @@ import { selectHiringActionDetails } from "../HiringActions/hiringActionSlice";
 const MetricsContainer = (props) => {
   const dispatch = useDispatch();
   const { hiringActionId } = props.match.params;
+  const currentHiringAction = useSelector(selectCurrentHiringActionId);
 
   const metricsStatus = useSelector(selectMetricsStatus);
 
@@ -31,7 +33,7 @@ const MetricsContainer = (props) => {
 
   const isLoading = metricsStatus === "pending" || metricsStatus === "idle";
   useEffect(() => {
-    if (metricsStatus === "idle") {
+    if (metricsStatus === "idle" || hiringActionId !== currentHiringAction) {
       dispatch(fetchMetrics(hiringActionId));
     }
   });

--- a/frontend/src/App/Metrics/metricsSlice.js
+++ b/frontend/src/App/Metrics/metricsSlice.js
@@ -12,7 +12,7 @@ export const fetchMetrics = createAsyncThunk(
   "metrics/fetchMetrics",
   async (assessmentHurdleId) => {
     const userMetrics = await fetchAssessmentHurdleMetrics(assessmentHurdleId);
-    return { userMetrics };
+    return { userMetrics, assessmentHurdleId };
   }
 );
 
@@ -22,6 +22,7 @@ export const metricsSlice = createSlice({
     error: "",
     status: "idle",
     metrics: {},
+    assessmentHurdleId: null,
   },
   extraReducers: {
     [fetchMetrics.pending]: (state, action) => {
@@ -29,10 +30,11 @@ export const metricsSlice = createSlice({
       state.error = "";
     },
     [fetchMetrics.fulfilled]: (state, { payload }) => {
-      const { userMetrics } = payload;
+      const { userMetrics, assessmentHurdleId } = payload;
       state.status = "fulfilled";
       state.error = "";
       state.metrics = userMetrics;
+      state.assessmentHurdleId = assessmentHurdleId;
     },
     [fetchMetrics.rejected]: (state, action) => {
       state.status = "rejectd";
@@ -43,4 +45,6 @@ export const metricsSlice = createSlice({
 
 export const selectMetrics = (state) => state.metrics.metrics;
 export const selectMetricsStatus = (state) => state.metrics.status;
+export const selectCurrentHiringActionId = (state) =>
+  state.metrics.assessmentHurdleId;
 export default metricsSlice.reducer;

--- a/frontend/src/App/Review/index.jsx
+++ b/frontend/src/App/Review/index.jsx
@@ -9,6 +9,7 @@ import {
   selectApprovedReviews,
   selectDeniedReviews,
   selectFlaggedReviews,
+  selectCurrentHiringActionId,
 } from "./reviewSlice";
 import { selectHiringActionDetails } from "../HiringActions/hiringActionSlice";
 import { withRouter } from "react-router-dom";
@@ -64,6 +65,7 @@ const ReviewContainer = (props) => {
   const dispatch = useDispatch();
   const { hiringActionId } = props.match.params;
   const reviewStatus = useSelector(selectReviewStatus);
+  const currentLoadedHiringAction = useSelector(selectCurrentHiringActionId);
   const hrStatsLink = `/hiring-action/metrics/${hiringActionId}`;
   const downloadUSASLink = `/api/assessment-hurdle/export/${hiringActionId}/resultsusas`;
 
@@ -84,7 +86,10 @@ const ReviewContainer = (props) => {
   } = hiringActionInfo;
   // const competenciesForReview = useSelector(selectCompetenciesForReview);
   useEffect(() => {
-    if (reviewStatus === "idle") {
+    if (
+      reviewStatus === "idle" ||
+      hiringActionId !== currentLoadedHiringAction
+    ) {
       dispatch(loadHiringActionDetails(hiringActionId));
     }
   });

--- a/frontend/src/App/Review/reviewSlice.js
+++ b/frontend/src/App/Review/reviewSlice.js
@@ -375,3 +375,5 @@ export const selectFlaggedReview = (id) => (state) => {
 export const selectAssessmentReview = (id) => (state) => {
   return state.review.applicantEvaluations[id];
 };
+export const selectCurrentHiringActionId = (state) =>
+  state.review.hiringActionId;


### PR DESCRIPTION
Messy hotfix here, long term solution is that we _really_ need to
simplify our lives by slapping the assessment_hurdle on everything.

It's not "normalized," but having to track all the way back from
4-5 nested deep things to get information about our hiring action
is not ideal.