### PR TITLE
Buildpack update and demo workflow

### DIFF
--- a/.github/workflows/push-demo.yml
+++ b/.github/workflows/push-demo.yml
@@ -1,0 +1,88 @@
+name: Deploy Demo
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      branch_name:
+        description: branch to deploy
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ inputs.branch_name }}
+
+      - uses: actions/cache@v2
+        id: api-npm-cache
+        with:
+          path: ./api/node_modules/
+          key: ${{ runner.os }}-api-npm-${{ hashFiles('./api/package-lock.json') }}
+
+      - uses: actions/cache@v2
+        id: frontend-npm-cache
+        with:
+          path: ./frontend/node_modules/
+          key: ${{ runner.os }}-frontend-npm-${{ hashFiles('./frontend/package-lock.json') }}
+
+      - uses: actions/cache@v2
+        id: frontend-scss-cache
+        with:
+          path: ./frontend/src/styles/
+          key: ${{ runner.os }}-frontend-scss-${{ hashFiles('./frontend/src/scss/**.scss') }}
+
+      # Notice that the cache for the frontend is actually in the api directory...
+      - uses: actions/cache@v2
+        id: frontend-src-cache
+        with:
+          path: ./api/src/client
+          key: ${{ runner.os }}-frontend-src-${{ hashFiles('./frontend/src/**/*', './frontend/package.json') }}
+
+      # Build frontend
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "12"
+
+      - name: Install frontend dependencies
+        if: steps.frontend-npm-cache.outputs.cache-hit != 'true'
+        run: npm ci
+        working-directory: frontend
+
+      - name: Build frontend styles
+        if: steps.frontend-scss-cache.outputs.cache-hit != 'true'
+        run: npm run build:styles
+        working-directory: frontend
+
+      - name: Build frontend
+        if: steps.frontend-src-cache.outputs.cache-hit != 'true'
+        run: npm run build:stage
+        working-directory: frontend
+
+      # Build backend
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+
+      - name: Install dependencies
+        if: steps.api-npm-cache.outputs.cache-hit != 'true'
+        run: npm ci
+        working-directory: api
+
+      # Because of how the deploy works, do not cache backend
+      # frontend changes _will not_ make it if that's the case
+      - name: Build backend
+        run: npm run build
+        working-directory: api
+
+      - name: Deploy to cloud.gov
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          cf_api: https://api.fr.cloud.gov
+          cf_username: ${{secrets.STAGE_CF_USERNAME}}
+          cf_password: ${{secrets.STAGE_CF_PASSWORD}}
+          cf_org: gsa-open-opportunities
+          cf_space: USDS
+          cf_manifest: deployDemo.yml

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.19.0-alpine
+FROM node:14.21.1-alpine
 
 WORKDIR /app
 

--- a/api/Dockerfile.compose
+++ b/api/Dockerfile.compose
@@ -1,4 +1,4 @@
-FROM node:14.19.0-alpine
+FROM node:14.21.1-alpine
 WORKDIR /opt/node_app/app
 
 COPY package.json package-lock.json ./

--- a/api/Dockerfile.dev
+++ b/api/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:14.19.0-alpine as builder
+FROM node:14.21.1-alpine as builder
 
 COPY package.json package-lock.json ./
 COPY tsconfig.json ./

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -70,7 +70,7 @@
         "typescript": "^4.1.3"
       },
       "engines": {
-        "node": "14.19.1"
+        "node": "14.21.1"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/api/package.json
+++ b/api/package.json
@@ -86,6 +86,6 @@
     "winston-daily-rotate-file": "^4.5.0"
   },
   "engines": {
-    "node": ">14.21.1 <15.0.0"
+    "node": "14.21.1"
   }
 }

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smeqa-art",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "",
   "main": "build/server.js",
   "scripts": {
@@ -86,6 +86,6 @@
     "winston-daily-rotate-file": "^4.5.0"
   },
   "engines": {
-    "node": ">14.19.0 <15.0.0"
+    "node": ">14.21.1 <15.0.0"
   }
 }

--- a/api/src/config/index.ts
+++ b/api/src/config/index.ts
@@ -1,7 +1,5 @@
 import path from 'path';
 import fs from 'fs';
-// const REDSREGEX = /"uri": "(redis:\/\/.*)"/;
-const PSQLREGEX = /"uri": "(postgres:\/\/.*)"/;
 
 export interface OpenIDConfiguration {
   issuerDiscover: string;
@@ -59,7 +57,7 @@ const env = process.env.APP_ENV?.toString() || 'development';
 
 const dbURI: string =
   process.env.POSTGRES_URI ||
-  (process.env.VCAP_SERVICES && process.env.VCAP_SERVICES.match(PSQLREGEX)![1]) ||
+  (process.env.VCAP_SERVICES && JSON.parse(process.env.VCAP_SERVICES)["aws-rds"][0].credentials.uri) ||
   'postgres://docker_pg_user:docker_pg_pw@docker_db:5432/docker_db';
 
 const openIdConfig: OpenIDConfiguration = {

--- a/deployDemo.yml
+++ b/deployDemo.yml
@@ -1,0 +1,17 @@
+version: 1
+applications:
+  - name: smeqa-demo
+    instances: 1
+    memory: 128MB
+    env:
+      NODE_ENV: production
+      APP_ENV: staging
+      OPTIMIZE_MEMORY: "true"
+      TZ: America/New_York
+    command: node server.js
+    type: nodejs
+    path: ./api/build
+    buildpack: nodejs_buildpack
+    stack: cflinuxfs3
+    services:
+      - smeqa-demo-db


### PR DESCRIPTION
Deployment of the app is currently not working due to use of a version of node that is not supported by the current nodejs buildpack used on cloud.gov.  To resolve that, this PR:

- Allows use of cloud foundry nodejs buildpack 1.8.3 (node 14.21.1)
- Adds a workflow to enable deployment to the demo environment