### PR TITLE
Update node versions in stage/prod workflows

### DIFF
--- a/.github/workflows/push-prod.yml
+++ b/.github/workflows/push-prod.yml
@@ -27,12 +27,6 @@ jobs:
     runs-on: ubuntu-latest
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: "14"
-
       # - uses: actions/cache@v2
       #   with:
       #     path: ~/.npm
@@ -65,7 +59,12 @@ jobs:
           path: ./api/src/client
           key: ${{ runner.os }}-frontend-src-prod-${{ hashFiles('./frontend/src/**/*', './frontend/package.json') }}
 
-      # Build frontend
+      # Build frontend (requires node 12)
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "12"
+
       - name: Install frontend dependencies
         if: steps.frontend-npm-cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -81,7 +80,12 @@ jobs:
         run: npm run build:prod
         working-directory: frontend
 
-      # Build backend
+      # Build backend (requires node 14)
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+
       - name: Install dependencies
         if: steps.api-npm-cache.outputs.cache-hit != 'true'
         run: npm ci

--- a/.github/workflows/push-staging.yml
+++ b/.github/workflows/push-staging.yml
@@ -27,12 +27,6 @@ jobs:
     runs-on: ubuntu-latest
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: "14"
-
       # - uses: actions/cache@v2
       #   with:
       #     path: ~/.npm
@@ -65,7 +59,12 @@ jobs:
           path: ./api/src/client
           key: ${{ runner.os }}-frontend-src-${{ hashFiles('./frontend/src/**/*', './frontend/package.json') }}
 
-      # Build frontend
+      # Build frontend (requires node 12)
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "12"
+
       - name: Install frontend dependencies
         if: steps.frontend-npm-cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -81,7 +80,12 @@ jobs:
         run: npm run build:stage
         working-directory: frontend
 
-      # Build backend
+      # Build backend (requires node 14)
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+
       - name: Install dependencies
         if: steps.api-npm-cache.outputs.cache-hit != 'true'
         run: npm ci


### PR DESCRIPTION
The build in github actions was failing, at least in part, because the frontend build fails with node 14.  As a temporary measure, use node 12 for that part of the workflow.

This updates the workflows to:
- build frontend with node 12
- build backend with node 14